### PR TITLE
add dependency for graphite-blueflood-finder to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'six',
     'structlog',
     'tzlocal',
+    'blueflood-graphite-finder',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
see request: 
  https://feedback.rackspace.com/forums/345663-metrics-as-a-service/suggestions/12353130-get-the-blueflood-python-module-required-by-grap

pypi package created and uploaded:
  https://pypi.python.org/pypi/blueflood-graphite-finder/0.0.1
